### PR TITLE
change query to find output by key rather than just index

### DIFF
--- a/bin/10-build-and-push-image.sh
+++ b/bin/10-build-and-push-image.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-ecrname=$(aws cloudformation describe-stacks --stack-name basic-app-ecr --query "Stacks[0].Outputs[0].OutputValue" --output text)
+ecrname=$(aws cloudformation describe-stacks --stack-name basic-app-ecr --query "Stacks[0].Outputs[?OutputKey=='RepositoryName'].OutputValue" --output text)
 commit=$(git describe --tags --always)
 
 docker build -t "$ecrname:$commit" . 


### PR DESCRIPTION
aws cli query for ecr name now finds output by KEY not index.